### PR TITLE
Initialize Electron project scaffold

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,39 @@
+# Environment configuration for HP/VVS Sales Automation desktop app
+# Primary spreadsheet IDs
+SPREADSHEET_ID=
+PAYMENTS_400_FILE_ID=
+HPUSA_301_FILE_ID=
+VVS_302_FILE_ID=
+HPUSA_SO_ROOT_FOLDER_ID=
+VVS_SO_ROOT_FOLDER_ID=
+
+# Intake & checklist templates
+INTAKE_TEMPLATE_ID_HPUSA=
+INTAKE_TEMPLATE_ID_VVS=
+CHECKLIST_TEMPLATE_ID_HPUSA=
+CHECKLIST_TEMPLATE_ID_VVS=
+QUOTATION_TEMPLATE_ID_HPUSA=
+QUOTATION_TEMPLATE_ID_VVS=
+HPUSA_DR_TEMPLATE_ID=
+VVS_SR_TEMPLATE_ID=
+
+# Per-client report configuration
+CS_REPORT_TEMPLATE_ID=
+REPORT_REANALYZE_TOKEN=
+# Legacy misspelling tolerated by config loader
+REPORT_REANLYZE_TOKEN=
+
+# Integrations (stubs in local runtime)
+OPENAI_API_KEY=
+TEAM_CHAT_WEBHOOK=
+MANAGER_CHAT_WEBHOOK=
+WEBAPP_EXEC_URL=
+
+# Debug flags
+DEBUG=false
+DEBUG_STRATEGIST=false
+RP_DEBUG=false
+REMIND_DEBUG_TEAM=false
+
+# Database
+DATABASE_PATH=./data/app.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+data/
+.env
+npm-debug.log*
+.DS_Store
+
+# SQLite temp files
+*.sqlite
+*.db
+*.db-journal
+*.db-shm
+*.db-wal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# HP / VVS Sales Automation — Desktop Local App
+
+This repository hosts the Electron-based port of the HP/VVS Sales Automation system. It mirrors the workflows defined in the legacy Apps Script project while running entirely on a local Node.js + SQLite stack.
+
+## Quickstart
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Configure environment**
+   ```bash
+   cp .env.sample .env
+   # edit .env with IDs and local paths from the Context Pack
+   ```
+3. **Run database migrations**
+   ```bash
+   npm run migrate
+   ```
+4. **Seed local fixtures**
+   ```bash
+   npm run seed
+   ```
+5. **Launch the desktop app**
+   ```bash
+   npm run dev
+   ```
+6. **Run tests**
+   ```bash
+   npm test
+   ```
+
+## Architecture
+
+The project follows a ports & adapters layout:
+
+- `src/main/` — Electron main process utilities (configuration, logging, database handle).
+- `src/adapters/` — Local implementations for workbook, ledger, Drive, scheduler, and per-client report services.
+- `src/domain/` — Business flows. `AppointmentSummary` provides the initial read-only smoke test.
+- `src/ui/` — Renderer assets for the Electron window.
+- `db/migrations/` — SQLite schema migrations.
+- `fixtures/` — CSV samples used to populate the local database.
+- `tests/` — Node-based smoke tests.
+
+All field names, aliases, and invariants trace back to [`docs/HP_VVS_Sales_Automation_Context_Pack.md`](docs/HP_VVS_Sales_Automation_Context_Pack.md), which remains the single source of truth.
+
+## Notes
+
+- The runtime enforces Pacific Time across scheduling and date parsing utilities.
+- Header access is always alias-driven; the helper utilities tolerate order changes and heal missing columns.
+- External integrations (OpenAI, Drive, Sheets) are stubbed locally for the v0 milestone.

--- a/db/migrations/001_init.sql
+++ b/db/migrations/001_init.sql
@@ -1,0 +1,121 @@
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS master (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  RootApptID TEXT NOT NULL,
+  VisitDate TEXT,
+  Customer TEXT,
+  Phone TEXT,
+  PhoneNorm TEXT,
+  Email TEXT,
+  EmailLower TEXT,
+  VisitType TEXT,
+  VisitNumber TEXT,
+  SO TEXT,
+  Brand TEXT,
+  SalesStage TEXT,
+  ConversionStatus TEXT,
+  CustomOrderStatus TEXT,
+  CenterStoneOrderStatus TEXT,
+  AssignedRep TEXT,
+  AssistedRep TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_master_root ON master(RootApptID);
+CREATE INDEX IF NOT EXISTS idx_master_visit_date ON master(VisitDate);
+
+CREATE TABLE IF NOT EXISTS client_status_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  LogDate TEXT,
+  SalesStage TEXT,
+  ConversionStatus TEXT,
+  CustomOrderStatus TEXT,
+  CenterStoneOrderStatus TEXT,
+  NextSteps TEXT,
+  DeadlineType TEXT,
+  DeadlineDate TEXT,
+  MoveCount INTEGER,
+  AssistedRep TEXT,
+  UpdatedBy TEXT,
+  UpdatedAt TEXT
+);
+
+CREATE TABLE IF NOT EXISTS ack_snapshot (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  SnapshotDate TEXT,
+  CapturedAt TEXT,
+  RootApptID TEXT,
+  Rep TEXT,
+  Role TEXT,
+  ScopeGroup TEXT,
+  CustomerName TEXT,
+  SalesStage TEXT,
+  ConversionStatus TEXT,
+  CustomOrderStatus TEXT,
+  UpdatedBy TEXT,
+  UpdatedAt TEXT,
+  DaysSinceLastUpdate INTEGER,
+  ClientStatusReportURL TEXT
+);
+
+CREATE TABLE IF NOT EXISTS ack_snapshot_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  SnapshotDate TEXT,
+  CapturedAt TEXT,
+  RootApptID TEXT,
+  Rep TEXT,
+  Role TEXT,
+  ScopeGroup TEXT,
+  CustomerName TEXT,
+  SalesStage TEXT,
+  ConversionStatus TEXT,
+  CustomOrderStatus TEXT,
+  UpdatedBy TEXT,
+  UpdatedAt TEXT,
+  DaysSinceLastUpdate INTEGER,
+  ClientStatusReportURL TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dashboard_weights (
+  Stage TEXT PRIMARY KEY,
+  Weight REAL
+);
+
+CREATE TABLE IF NOT EXISTS client_status_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  RootApptID TEXT NOT NULL,
+  LogDate TEXT,
+  SalesStage TEXT,
+  ConversionStatus TEXT,
+  CustomOrderStatus TEXT,
+  CenterStoneOrderStatus TEXT,
+  NextSteps TEXT,
+  DeadlineType TEXT,
+  DeadlineDate TEXT,
+  MoveCount INTEGER,
+  AssistedRep TEXT,
+  UpdatedBy TEXT,
+  UpdatedAt TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_client_status_entries_root ON client_status_entries(RootApptID);
+
+CREATE TABLE IF NOT EXISTS payments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  RootApptID TEXT,
+  PaymentDateTime TEXT,
+  DocType TEXT,
+  AmountNet REAL,
+  DocStatus TEXT,
+  Raw TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_payments_root ON payments(RootApptID);
+CREATE INDEX IF NOT EXISTS idx_payments_date ON payments(PaymentDateTime);
+
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+
+COMMIT;

--- a/docs/HP_VVS_Sales_Automation_Context_Pack.md
+++ b/docs/HP_VVS_Sales_Automation_Context_Pack.md
@@ -1,0 +1,334 @@
+# Context Pack — HP / VVS Sales Automation → Desktop Local (Electron)
+
+**Goal:** Rebuild the existing Google Apps Script system as a local desktop app (Node/Electron + HTML UI). Keep behaviors and data contracts **identical** unless called out below.
+
+---
+
+## 0) High‑level system map
+
+**Primary workbook (the “100_ file”)**  
+- **Main tab:** `00_Master Appointments` — *single source of truth* for customer rows and visit history. Multiple modules read/write via robust header matching (aliases). 【turn27file3】  
+- **Other in‑workbook tabs used by code:**  
+  - `03_Client_Status_Log` (historical log per client row; also mirrored to per‑client reports), `07_Root_Index`, `08_Reps_Map`, `00_Dashboard`, `100_Metrics_View`. These names are referenced in the dashboard code and helper constants. 【turn26file6】
+
+**Per‑client report files**  
+- Each client has a dedicated Google Sheet (created on demand) with a tab **“Client Status”** whose **header row is 14**; columns listed under §3.2. The app appends log rows here and updates a summary “snapshot” block on the sheet. 【turn26file3】【turn26file8】
+
+**Payments ledger workbook (“400_ ledger”)**  
+- Tab: **`Payments`**. Code reads/writes using **tolerant header detection** for: `RootApptID`, `PaymentDateTime`, `DocType`, `AmountNet`, and (optional) `DocStatus`. These columns may appear under flexible aliases (e.g., *“Payment Date”, “Paid At”* for date; *“Net”, “Net Amount”* for amount). Ignore void/reversed rows. 【turn25file2】
+
+**Acknowledgements (daily ops)**  
+- Uses two snapshot tabs in the main workbook: **`13_Morning_Snapshot`** and **`14_Snapshot_Log`** with explicit headers (see §3.3). A morning trigger captures the expected set at ~8:30 AM PT and appends audit rows. Queues per rep are built from that snapshot. 【turn25file16】【turn26file2】
+
+**Dashboard**  
+- Works entirely off in‑memory reads + a “metrics” view (`100_Metrics_View`) and writes KPI blocks on `00_Dashboard`. Stage weights live at **`00_Dashboard!AS30:AT60`** (defaults provided if blank). Preset date filters write to **B1/B2/D2**; brand/rep filters live in **H1:I1 / H2:I2** (reads use the left/top cell). 【turn26file6】【turn26file14】
+
+---
+
+## 1) Runtime & configuration (to replicate)
+
+**Default timezone & scopes (source project)**  
+- Timezone is **America/Los_Angeles**; code often formats date‑only logs and schedules around PT. Preserve this as app default unless overridden. 【turn25file3】
+
+**Script Properties (required keys)**  
+Codex must surface a settings panel or `.env` for these (names **exactly** as listed; many are referenced by alias maps in code).  
+- IDs & templates:  
+  `SPREADSHEET_ID`, `PAYMENTS_400_FILE_ID`, `HPUSA_301_FILE_ID`, `VVS_302_FILE_ID`,  
+  `HPUSA_SO_ROOT_FOLDER_ID`, `VVS_SO_ROOT_FOLDER_ID`,  
+  `INTAKE_TEMPLATE_ID_HPUSA`, `INTAKE_TEMPLATE_ID_VVS`,  
+  `CHECKLIST_TEMPLATE_ID_HPUSA`, `CHECKLIST_TEMPLATE_ID_VVS`,  
+  `QUOTATION_TEMPLATE_ID_HPUSA`, `QUOTATION_TEMPLATE_ID_VVS`. 【turn25file10】  
+- Per‑client report template token & analyzer:  
+  `CS_REPORT_TEMPLATE_ID`, `REPORT_REANALYZE_TOKEN` (note: one variant key is misspelled `REPORT_REANLYZE_TOKEN` and exists in props; tolerate both). 【turn25file10】  
+- OpenAI & webhooks:  
+  `OPENAI_API_KEY`, `TEAM_CHAT_WEBHOOK`, `MANAGER_CHAT_WEBHOOK`, `WEBAPP_EXEC_URL`. 【turn25file10】  
+- Misc flags / debug: `DEBUG`, `DEBUG_STRATEGIST`, `RP_DEBUG`, `REMIND_DEBUG_TEAM`, plus brand‑specific doc template IDs (e.g., `HPUSA_DR_TEMPLATE_ID`, `VVS_SR_TEMPLATE_ID`). 【turn25file10】
+
+> **Finding IDs from URLs:** the legacy system extracts a Drive ID from **either** `/d/<id>` **or** `?id=<id>` or any 25+ char token. Preserve this tolerant behavior. 【turn25file3】
+
+---
+
+## 2) Triggers & automation (behavior to preserve)
+
+**What currently runs on schedules (Apps Script → Desktop cron/daemon):**  
+- **Acknowledgements suite:**  
+  - **Morning**: build expected set & snapshot (~8:25–8:30 AM PT), build queues and dashboard.  
+  - **Midday**: optional queues refresh (1:00 PM PT).  
+  - **Late‑day**: optional dashboard rebuild (4:30 PM PT). Codex: replicate as local scheduled jobs. 【turn26file17】【turn25file16】  
+- **Dashboard hourly** and **reminders daily** exist in the project; include equivalent schedulers. The project’s packer also snapshots triggers into `TRIGGERS.json`. 【turn25file1】
+
+**Pack/export behavior (for your knowledge pack and parity checks):**  
+- The project can **export a pack** with: `FUNCTION_INDEX.json`, `SCRIPT_PROPERTY_KEYS.json`, a triggers snapshot, and discovered sheet schemas for each configured workbook ID. Preserve a similar “export state” diagnostic in the desktop app for parity debugging. 【turn25file1】【turn27file2】
+
+---
+
+## 3) Data contracts (tabs, headers, shapes)
+
+### 3.1 Master workbook: `00_Master Appointments`
+
+This is the **authoritative** table of customers and appointments. Many modules use robust “first header index by alias” matchers (e.g., `Visit Date`, `RootApptID`, `Customer Name`, `Assigned Rep`/`Assisted Rep`, `SO#`, `Sales Stage`, `Conversion Status`, `Custom Order Status`, `Center Stone Order Status`, `Brand`, `Phone`, `Email`, `PhoneNorm`, `EmailLower`). A dedicated “Appointment Summary” feature confirms these columns and returns a canonical view:  
+
+**Appointment Summary output columns (order):**  
+`Visit Date, RootApptID, Customer, Phone, Email, Visit Type, Visit #, SO#, Brand, Sales Stage, Conversion Status, Custom Order Status, Center Stone Order Status` (plus `Assigned Rep`, `Assisted Rep` in the server config). Keep the aliases tolerant during reads. 【turn27file3】
+
+### 3.2 Per‑client report (Google Sheet per customer)
+
+- **Tab name:** `Client Status`.  
+- **Header row:** **14**.  
+- **Required columns** (exact names used for writes/appends):  
+  `Log Date | Sales Stage | Conversion Status | Custom Order Status | Center Stone Order Status | Next Steps | Deadline Type | Deadline Date | Move Count | Assisted Rep | Updated By | Updated At`.  
+- The “Record Deadline” dialog reads the active row in **Master**, increments *# moved* counters, and appends to this per‑client log using the URL in **“Client Status Report URL”** on the Master row. Codex must keep the **exact** column names and row index (14). 【turn26file8】【turn26file3】【turn26file14】
+
+> The **Client Status** submit flow also **ensures** this per‑client report exists; if the URL/ID is missing or invalid, the system creates one from a template, writes a `_Config` block (including `RootApptID` and the report ID), and then logs/snapshots the update. Preserve this lifecycle. 【turn26file10】
+
+### 3.3 Acknowledgement snapshot/log (in main workbook)
+
+- **Tabs:** `13_Morning_Snapshot`, `14_Snapshot_Log`.  
+- **Header set** (both sheets share it and the code heals headers to match):  
+  `Snapshot Date, Captured At, RootApptID, Rep, Role, Scope Group, Customer Name, Sales Stage, Conversion Status, Custom Order Status, Updated By, Updated At, Days Since Last Update, Client Status Report URL`. 【turn26file2】
+
+### 3.4 `03_Client_Status_Log` (main workbook)
+
+- Historical log of Client Status changes made from the dialog. A one‑time audit utility **adds** a trailing column **“In Production Status”** if missing (header only). Codex: keep header‑aware appends and header‑healing behavior. 【turn26file7】
+
+### 3.5 Dashboard & metrics
+
+- **Stage Weights table** lives at **`00_Dashboard!AS30:AT60`**. If empty, seed with defaults:
+
+  | Stage             | Weight |
+  |-------------------|--------|
+  | LEAD              | 0.10   |
+  | HOT LEAD          | 0.20   |
+  | CONSULT           | 0.30   |
+  | DIAMOND VIEWING   | 0.50   |
+  | DEPOSIT           | 0.90   |
+  | ORDER COMPLETED   | 0.00   |
+
+  Reads are case‑insensitive; code falls back to the above set if the block is blank. 【turn25file14】
+
+- **Filter inputs** on `00_Dashboard`:  
+  presets at **B1** (merged B1:D1), date range **B2 .. D2**, brand at **H1:I1** (read **I1**), rep at **H2:I2** (read **I2**). The “preset” selector fills the dates for This/Last week, This/Last month, QTD, YTD. **Replicate this UX.** 【turn26file14】【turn26file6】
+
+- Dashboard derives KPIs such as **Deposits (first‑time/all)** by combining Master with the **400 ledger**, and a **Weighted Pipeline** using Stage Weights (above). “Receipt” rows are considered only if `DocType` matches /receipt/i, net > 0, and not voided/cancelled. **Keep these filters.** 【turn25file2】【turn25file7】
+
+### 3.6 400_ Payments ledger
+
+- **Reads:** tolerant header aliases. Required fields when scanning:  
+  - Root: `RootApptID` (alias: *Root Appt ID, ROOT, Root_ID*).  
+  - When: `PaymentDateTime` (alias: *Payment DateTime, Payment Date, Paid At*).  
+  - Type: `DocType` (alias: *Document Type*).  
+  - Net: `AmountNet` (alias: *Net, Net Amount*).  
+  - Optional: `DocStatus` (alias: *Status*).  
+  Filter to “Receipt” doc types, positive net, and drop void/reversed/cancelled. Used to find **first real deposit** (ignore tiny holds) and to compile “all deposits in window”. 【turn25file14】【turn25file2】【turn25file17】
+
+- **Writes:** the “Record Payment” dialog writes a ledger row object that includes (at least):  
+  `PAYMENT_ID, Brand, RootApptID, SO#, AnchorType, BasketID, DocType, PaymentDateTime, Method, Reference, Notes, AmountGross, FeePercent, FeeAmount, AmountNet, AllocatedToSO, LinesJSON, Subtotal, Order Total_SO, Paid-To-Date_SO, Balance_SO, Submitted By, Submitted Date/Time`. Headers are **ensured/created** and writing uses a header map (order‑agnostic). **Keep this contract.** 【turn26file16】
+
+---
+
+## 4) Major modules — responsibilities & contracts
+
+### 4.1 Conversations & Summaries Suite
+
+**Purpose:** Ingest consult audio/transcripts, build **Scribe** (facts) and **Strategist** (analysis) JSONs, save them under the client folder (`04_Summaries`), optionally read **newest transcript** from `03_Transcripts`, and write a normalized snapshot & SYS table entry. 【turn25file4】【turn27file17】
+
+**Key behaviors to preserve:**
+- **Newest artifact selection**: prefer `__summary_corrected_*.json` over base `__summary_*.json`; similar logic for strategist `__analysis_*.json`. **Newest by lastUpdated or created time**. 【turn25file4】【turn25file19】  
+- **Transcript fallback**: pick newest `.txt` in `03_Transcripts/` and inject a Drive **view URL** for reference. 【turn27file11】  
+- **Master‑owned identity**: After Scribe, inject `customer_name`, `phone`, `email` from Master (using tolerant header indexes: prefers display columns, falls back to normalized). 【turn27file17】  
+- **Upload queue**: a WebApp `doPost` adds items; workers `processUploadQueue` and `processSummariesWorker` batch process and write into SYS tables. Preserve *idempotent* workers and chunking semantics. 【turn26file5】  
+- **Schema discipline**: internal diagnostics check that **every object with properties has a full `.required` array**; keep this strictness when calling OpenAI’s JSON schema. 【turn27file9】
+
+**Inputs:** RootApptID, newest transcript (optional), existing Scribe/Strategist JSONs.  
+**Outputs:** Saved Scribe/Strategist JSON + URLs; updated SYS_Consults row; refreshed per‑client report (when applicable). 【turn25file19】
+
+---
+
+### 4.2 Client Status (Server + Dialog)
+
+**Purpose:** Let reps update Sales Stage / Conversion / Order statuses, **append** to both the **main log** (*03_Client_Status_Log*) and the **per‑client report** (*Client Status tab, row 14 headers*), then **snapshot** the summary block in the per‑client sheet. If the per‑client report is missing/invalid, **create** it and write a `_Config`. Also mirror “Updated By/At” back to Master if those columns exist. 【turn26file10】
+
+**Key behaviors to preserve:**
+- **Header‑aware writes**: build a map from the current header row; *order cannot be assumed*. 【turn26file10】  
+- **One‑time audit**: if `03_Client_Status_Log` lacks **“In Production Status”**, append that header as the **last** column (no shifting). 【turn26file7】  
+- **Date normalization** for input controls (ISO `YYYY-MM-DD`) from mixed formats. 【turn26file0】  
+- **Allowed lists** for dialog dropdowns are read from sheet ranges (Stage/Conv/COS/Center Stone); keep this externalized (source: status dropdowns & “Stage Weights”). *Note: the code references reading “Dropdowns” and weight tables to drive UI; replicate through configuration rather than hardcoding.*
+
+**Per‑client log contract:** see §3.2.  
+**Snapshot block fields:** includes brand, client, APPT_ID, AssignedRep, order date, sales stage/state fields, and last update identity and time. These are written into fixed labeled cells; order date is specifically placed when a “Order Date:” label exists (matches current behavior). 【turn26file10】
+
+---
+
+### 4.3 Deadlines (3D / Production)
+
+**Purpose:** A modal lets a rep set or move **3D** and **Production** deadlines for the selected Master row; it increments “# moved” counters on Master and appends a **deadline log** row to the client’s **Client Status** tab (row 14 headers). **Required Master headers** must be present before logging. 【turn26file8】【turn26file3】
+
+- **Master sheet required headers** (row 1; order agnostic):  
+  `3D Deadline`, `# of Times 3D Deadline Moved`, `Production Deadline`, `# of Times Prod. Deadline Moved`, `Client Status Report URL`. Optional: `Assisted Rep`. 【turn26file8】  
+- **Target log columns (per‑client)**: exact names in §3.2. 【turn26file8】
+
+---
+
+### 4.4 Acknowledgements Suite (Queues + Snapshot + Dashboard)
+
+**Purpose:** Daily coverage workflow that (A) computes **expected** acknowledgment workload per rep (including assisted coverage pairing), (B) writes a **Morning Snapshot** + **Snapshot Log**, (C) builds per‑rep **Ack queues** with headers and validations, and (D) renders a **Clients by Stage** dashboard sectioned by canonical stages. 【turn25file16】【turn26file1】【turn25file13】
+
+**Key behaviors to preserve:**
+- **Coverage pairing:** a “partner coverage” map (e.g., *Maria & Paul*) is honored; if both off ⇒ “Assisted Coverage Gap”. Otherwise, duties may route to partner with `Assigned` vs `Assisted` roles derived from original assignment. 【turn25file16】  
+- **Queue header and DV:** Each rep’s tab adds **`Ack Status`** (validated dropdown) and **`Ack Note`** input columns; **Updated At** gets datetime format; autosize columns; freeze header row. 【turn26file1】  
+- **Snapshot header healing:** both `13_Morning_Snapshot` and `14_Snapshot_Log` are actively **healed** to the canonical header set (see §3.3) and width‑adjusted (insert/delete columns to match). 【turn26file2】  
+- **Stage‑bucketed dashboard list:** “Clients by Stage” sorts rows by *(1) has past visit* then by *oldest→newest* using the relevant date (last past or next future). Deposit/Won rows gain **financial enrichment** (First Deposit Date/Amount, Order Total, Paid‑to‑Date, Outstanding), if available. Keep this four‑step pipeline: **collect → bucket → sort → flatten with section headers**. 【turn25file8】【turn25file13】
+
+**Triggers to replicate:** morning snapshot (~8:30), optional midday queue refresh (1:00 PM), late‑day dashboard refresh (4:30 PM). 【turn26file17】
+
+---
+
+### 4.5 Dashboard (KPI & cohort charts)
+
+**Purpose:** Build `100_Metrics_View`, render KPI cards on `00_Dashboard`, and maintain a hidden **history block** for sparklines (columns **AA..AP**, header at row **5**). Stage Weights from `AS30:AT60`. Filter inputs and preset logic set **B1/B2/D2** and **I1/I2**. **No 99_* staging tabs** are required; code reads ledger live for counts/sums. 【turn26file6】【turn26file14】【turn25file2】
+
+- **Weekly totals table** persisted in hidden area (for charts): `Week | Consultations | Diamond Viewings | First Deposits (#) | First Deposit Sum ($)`; numeric formats as in legacy. Replicate this layout/formatting. 【turn26file9】
+
+---
+
+### 4.6 Payments — Record & Summary
+
+**Record Payment (dialog + server)**  
+- **Prefill** shows prior payments (last payment date), order totals/paid‑to‑date/balance, and lines from Master/Orders when available. Provides “Build line from 3D” (formats a setting spec from tracker log into a line). **Keep this UX affordance.** 【turn27file4】【turn26file11】  
+- **Key config alias map** (must be preserved): *many property names are accepted for each setting*. Example: `LEDGER_FILE_ID` may come from `PAYMENTS_400_FILE_ID`, `LEDGER_FILE_ID`, `PAYMENTS_LEDGER_FILE_ID`, etc. Codex: implement a **key alias resolver** using the lists in the legacy code. The map also covers **orders files/tabs**, **doc templates** (DI/DR/SI/SR per brand), **AR root folders**, **fees**, **SO_ROOT_FOLDER_ID**, and **SO_RECEIPT_MASTER_AMOUNT**. 【turn25file12】  
+- **Doc role inference**: If the dialog leaves role blank, infer from DocType: *CREDIT, PROGRESS, DEPOSIT (for deposit invoice), FINAL (invoice), else SALES_RECEIPT if there are lines, otherwise PAYMENT_RECEIPT*. **Uppercase canonicalization** applies. 【turn26file16】  
+- **Ledger write:** see the **row object** in §3.6; headers are ensured/created and the write is order‑agnostic via a header map. 【turn26file16】
+
+**Payment Summary (read‑only)**  
+- Server functions (`ps_*`) parse doc lines, guess doc types, fetch history for an anchor (APPT/SO), and export to PDF. Maintain these read/format behaviors. (Function set confirmed in index.) 【turn27file16】
+
+---
+
+### 4.7 Diamonds — propose, quotation, order, delivery, decisions
+
+**Quotation / Settings update**  
+- **Quotation Settings** expects a named anchor cell (e.g., *“Ring Settings”* anchor). Code scans a rectangular window from that anchor, **builds a header vector** (flexible matching), maps **columns by candidates**, and allows batched add/remove/save of rows with fields:  
+  `product, styleDetail, metal, bandWidth, ringSize, freeUpgrade, onlineRetailerPrice, brilliantEarthPriceAfterTax, vvsPrice, yourSavings, link`. **At least one of Product/Style Detail is required per row**. Keep right‑aligned numeric fields listed. UI shows a small **Quotation chip** if a URL is available. 【turn25file5】【turn25file11】
+
+**3D Tracker versions**  
+- The update flow can read the 3D **Tracker “Log”** tab (or `3D Log` / `3D Revision Log`) to list versions with timestamp/revision and setting snippets (ring style/metal/band/size). The 3D **Tracker URL** comes from the `3D Tracker` cell on the Master row. **Robust file‑ID extraction** applies. 【turn26file18】
+
+**Order Approvals / Confirm Delivery / Stone Decisions**  
+- Present as dedicated dialogs with server helpers to read/write the `200_`/orders sheet and update the `100_` summary. Maintain the flows as separate steps with their existing function sets (see function index). **Do not change column names; rely on alias lookups**. 【turn27file6】【turn27file12】【turn27file13】
+
+---
+
+## 5) Read/Write rules & invariants (carry over exactly)
+
+1) **Header‑agnostic I/O** everywhere  
+   - Build **header maps** from the live sheet row and always write by **name** (with case‑insensitive lookup of first match). Do **not** hard‑address columns by index. Helpers like `createHeaderMapFromRow_`, `getHeaderMap_` are canonical. 【turn26file3】【turn27file14】
+
+2) **Flexible alias matching**  
+   - For common fields (RootApptID, SO#, PaymentDateTime, etc.), accept a **set of aliases** and pick the first present. This pattern is pervasive (e.g., ledger, dashboard, reports). **Codex must implement a central alias registry.** 【turn25file2】【turn26file12】
+
+3) **Financial filters**  
+   - When counting/summing deposits: include only **receipt‑type** docs, positive net, **exclude** void/reversed/cancelled; optionally restrict to brand/rep or date window. 【turn25file2】【turn25file17】
+
+4) **Dates**  
+   - Log dates as date‑only (midnight) for “Log Date”; include separate **“Updated At”** timestamps with datetime formatting. Keep PT defaults. 【turn26file3】【turn26file1】
+
+5) **Morning Snapshot contract**  
+   - Write/Heal headers exactly as in §3.3; log captures post‑coverage expansion (partner duties), and persists a daily audit to `14_Snapshot_Log`. 【turn26file2】【turn25file16】
+
+6) **UI consistency**  
+   - Dialogs resize to fit content; buttons disabled until valid; list/table rendering uses **batched DOM writes** and **delegated events** (performance patterns). Preserve these UX patterns when rebuilding. (Confirmed across dialogs like quotation & payments.) 【turn25file11】【turn26file11】
+
+---
+
+## 6) Reports (status/by‑rep/KPI) — shaping rules
+
+- **By Rep / By Status** shapers **insert `Order Total` and `Total Pay To Date` immediately after `Visit Date`** and may optionally insert production columns (**`In Production Status`** + **`Production Deadline`**) after **`Custom Order Status`** when requested (`includeProductionCols=true`). **Assisted Rep** shows *“Assisted (LastUpdatedByNameOrEmail)”* by mapping the last updated email to a display name (cached). **Replicate these transforms exactly.** 【turn26file12】【turn27file19】
+
+- Generic “shape” for status uses a fixed minimal column set:  
+  `APPT_ID, Customer Name, Assigned Rep, Brand, SO#, Sales Stage, Conversion Status, Custom Order Status, Center Stone Order Status, Next Steps, Client Status Report URL`. 【turn27file19】
+
+---
+
+## 7) Function surface (for parity testing)
+
+Your original project enumerates callable server/UI functions. Use this to define **feature parity tests** and menu wiring in the desktop app:
+
+- **Appointment Summary**: `as_openAppointmentSummary`, `as_runAppointmentSummary`, + helpers. Output columns listed in §3.1. 【turn27file0】  
+- **Client Status**: `cs_openStatusDialog_`, `cs_submitFromDialog`, `ensureReportConfig_`, etc. 【turn27file15】  
+- **Deadlines**: `showRecordDeadlineDialog`, `getRecordDeadlineInit`, `saveRecordDeadline`. 【turn27file5】  
+- **Payments**: `openRecordPayment`, `rp_init`, `rp_submit`, `rp_listDocNumbersForAnchor`, plus `ps_init` / `ps_exportPdf` for summary. 【turn27file10】【turn27file16】  
+- **3D / Diamonds**: `start3d_*`, `open3DRevision` + `rev3d_*`, `dp_openProposeDiamonds`, `uq_openUpdateQuotationDiamonds`, order/confirm/decision dialog pairs. 【turn27file10】【turn27file6】  
+- **Reminders & DV queues**: `DV_*` and `DVQ_*` functions (team/manager messages, daily urgent, propose nudges). Keep queue ID and date keying semantics identical. 【turn27file5】
+
+---
+
+## 8) Desktop‑local rebuild — adapter plan (no code here; architecture only)
+
+Codex, implement **adapters** to preserve behaviors:
+
+1) **Storage**  
+   - **Sheets adapter**: emulate header‑map I/O against local stores (SQLite or on‑disk CSV/Parquet). Maintain **order‑agnostic writes** by column name and **alias matching**.  
+   - **Per‑client report**: represent each report as a local workbook (SQLite table + a JSON `_Config` row) with a **“Client Status”** table whose **schema matches §3.2** and whose **header row index = 14** is preserved logically (store as metadata; the UI should still render “row 14 header” to mimic parity).  
+   - **Ledger adapter**: a table `Payments` with tolerant aliases for the five required fields and additional columns used by **rp_submit** (§3.6).  
+
+2) **File system (Drive)**  
+   - Emulate `RootAppt Folder` with a directory tree: per‑client folder contains `03_Transcripts`, `04_Summaries`, `05_ChatLogs`. Newest‑file selection and naming rules must match (regexes for `__summary__`, `__summary_corrected__`, `__analysis__`). 【turn25file4】【turn27file11】
+
+3) **Schedulers**  
+   - Cron/daemon tasks to replicate **morning snapshot**, **midday queues**, **late‑day dashboard**, **hourly dashboard**, **daily reminders**. PT default. Logging & idempotency required (skip if already ran for day). 【turn26file17】
+
+4) **OpenAI**  
+   - Maintain **JSON‑schema strictness checks** (required arrays on every object), and keep the **newest transcript** loading and **Master identity injection** behaviors. 【turn27file9】【turn27file17】
+
+5) **UI**  
+   - **Modal dialogs** (payments, deadlines, client status, diamonds flows): keep button‑disable logic, batched rendering, and toast/resize behaviors. (Examples: `fitDialog`, batched DOM writes, delegated events). 【turn26file11】【turn25file11】  
+   - **Dashboard**: replicate filter cells (preset/date/brand/rep) and the history/kpi blocks; copy the *preset* semantics (“this week”, “last month”, etc.). 【turn26file14】
+
+---
+
+## 9) Non‑goals / constraints (for Codex)
+
+- **Do not** change header names or their row indices where specified (e.g., **Client Status row 14**). 【turn26file8】  
+- **Do not** convert tolerant ID parsing or column aliasing into strict single‑name lookups. Keep alias resolution exactly as described. 【turn25file3】【turn25file14】  
+- **Do not** drop the financial filters (receipt‑type, positive net, non‑void). Dashboard and KPIs depend on them. 【turn25file2】
+
+---
+
+## 10) Acceptance checks (ready‑made parity tests)
+
+- **Log append parity:** Given a Master row with a valid *Client Status Report URL*, creating a 3D/Production deadline writes a row with the **12 exact columns** in §3.2 to the per‑client `Client Status` tab. 【turn26file8】  
+- **Morning snapshot parity:** Running the morning job creates/updates `13_Morning_Snapshot` with the header set in §3.3 and appends to `14_Snapshot_Log`. **Headers heal** if width mismatches. 【turn26file2】  
+- **Dashboard stage weights:** With `AS30:AT36` blank, seeding produces the exact six rows in §3.5. Weighted pipeline uses these values. 【turn25file14】  
+- **Ledger scanning:** Counting “all deposits in window” uses the alias set and exclusion rules; returns **0** on missing `PAYMENTS_400_FILE_ID` fail‑soft. 【turn25file17】  
+- **Record Payment write:** Submitting writes the full row object listed in §3.6; headers are created if missing; **DocRole** auto‑inferred if not supplied. 【turn26file16】
+
+---
+
+## 11) Appendix — Handy reference (names & files)
+
+- **Key tabs (main workbook):**  
+  `00_Master Appointments`, `03_Client_Status_Log`, `07_Root_Index`, `08_Reps_Map`, `13_Morning_Snapshot`, `14_Snapshot_Log`, `00_Dashboard`, `100_Metrics_View`. 【turn26file6】【turn26file2】  
+- **Per‑client report (each customer):** `Client Status` (row‑14 headers) + `_Config`. 【turn26file8】  
+- **Ledger workbook:** `Payments` tab; alias matching for key columns. 【turn25file2】  
+- **Function indices** for: Appointment Summary, Client Status, Deadlines, Payments (RP/PS), Start/Assign 3D, Revisions, Diamonds flows, Reminders/Queues — use `FUNCTION_INDEX.json` as the authoritative list of callable functions/features to re‑expose. 【turn27file0】【turn27file15】
+
+---
+
+### Notes on provenance
+
+- Timezone & scopes: **America/Los_Angeles**; export pack & sheet schema snapshots exist in Core & Config. 【turn25file3】【turn25file1】  
+- Properties (IDs & tokens) come from the serialized `SCRIPT_PROPERTY_KEYS.json`. **Treat misspellings as tolerated variants** when present (e.g., `REPORT_REANLYZE_TOKEN`). 【turn25file10】  
+- Stage weights & dashboard contracts: `00_Dashboard` code paths. 【turn25file14】【turn26file6】  
+- Acknowledgements: pairing logic, snapshot healing, queue building, and scheduler times. 【turn25file16】【turn26file1】【turn26file17】  
+- Payments: alias map, role inference, ledger write shape, and prefill behaviors. 【turn25file12】【turn26file16】【turn27file4】  
+- Reports: log append to per‑client sheet and “shape” functions for By‑Rep/Status. 【turn26file3】【turn26file12】
+
+---
+
+## 12) What Codex should build first (recommended order)
+
+1) **Adapters**: Sheets (header map + alias registry), Ledger, Per‑client Report, Drive‑like folders.  
+2) **Schedulers**: morning snapshot → queues → dashboard; hourly dashboard; daily reminders.  
+3) **UI**: Client Status dialog → Deadlines → Payments → Appointment Summary → Diamonds dialogs.  
+4) **Reports**: By Rep / By Status shaping + exports.  
+5) **Conversations**: Scribe/Strategist ingestion, newest artifact resolution, identity injection.

--- a/fixtures/ledger.sample.csv
+++ b/fixtures/ledger.sample.csv
@@ -1,0 +1,5 @@
+Root_ID,Payment Date,Document Type,Net Amount,Status
+HP-1001,2024-04-02T10:00:00,Deposit Receipt,2500,Posted
+HP-1002,2024-04-04T09:00:00,Receipt,3500,Completed
+HP-1002,2024-04-04T12:30:00,Refund,-200,Completed
+HP-1003,2024-04-06T15:00:00,Receipt,0,Cancelled

--- a/fixtures/master.sample.csv
+++ b/fixtures/master.sample.csv
@@ -1,0 +1,4 @@
+Customer Name,Visit Date,Root Appt ID,Primary Phone,Phone (Normalized),Email,Email Lower,Appt Type,Visit #,SO Number,Brand,Stage,Conversion Status,Custom Status,Center Stone Status,Assigned Rep,Assisted Rep
+Alice Example,2024-04-01,HP-1001,555-111-2222,15551112222,alice@example.com,alice@example.com,Consult,1,SO-9001,HPUSA,Consult,In Progress,Pending Design,In Queue,Jamie Rep,Sky Helper
+Bob Sample,2024-04-03,HP-1002,555-333-4444,15553334444,bob@sample.com,bob@sample.com,Diamond Viewing,2,SO-9002,VVS,Deposit,Won,Production,Ordered,Kelly Rep,Jamie Rep
+Cara Client,2024-04-05,HP-1003,555-666-7777,15556667777,cara@client.com,cara@client.com,Consult,1,,HPUSA,Lead,New Lead,New,Not Started,Jamie Rep,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hp-vvs-standalone-app",
+  "version": "0.1.0",
+  "description": "Desktop local port of HP/VVS Sales Automation",
+  "main": "src/main/electron.js",
+  "type": "module",
+  "scripts": {
+    "dev": "electron .",
+    "migrate": "node scripts/migrate.js",
+    "seed": "node scripts/seed.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "better-sqlite3": "^8.6.0",
+    "csv-parse": "^5.5.4",
+    "dotenv": "^16.4.5",
+    "luxon": "^3.4.4"
+  },
+  "devDependencies": {
+    "electron": "^29.0.0"
+  }
+}

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getDatabase } from '../src/main/db.js';
+import { logger } from '../src/main/logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function runMigrations() {
+  const db = getDatabase();
+  const migrationsDir = path.resolve(__dirname, '../db/migrations');
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const file of files) {
+    const fullPath = path.join(migrationsDir, file);
+    const sql = fs.readFileSync(fullPath, 'utf8');
+    logger.info('Running migration %s', file);
+    db.exec(sql);
+  }
+  logger.info('Migrations complete.');
+}
+
+if (process.argv[1] === __filename) {
+  runMigrations();
+}

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'csv-parse/sync';
+import { getDatabase } from '../src/main/db.js';
+import { logger } from '../src/main/logger.js';
+import { MASTER_HEADER_ALIASES, LEDGER_HEADER_ALIASES } from '../src/main/alias-registry.js';
+import { normalizeHeaderName } from '../src/main/utils/headerMap.js';
+import { formatDate, toPacific } from '../src/main/utils/time.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createNormalizedMap(record) {
+  const map = new Map();
+  Object.entries(record).forEach(([key, value]) => {
+    map.set(normalizeHeaderName(key), value);
+  });
+  return map;
+}
+
+function resolveField(map, canonical, aliasSet) {
+  const aliases = aliasSet[canonical] || [canonical];
+  for (const candidate of aliases) {
+    const normalized = normalizeHeaderName(candidate);
+    if (map.has(normalized)) {
+      return map.get(normalized);
+    }
+  }
+  return null;
+}
+
+function normalizePhone(phone) {
+  if (!phone) {
+    return null;
+  }
+  const digits = phone.toString().replace(/\D+/g, '');
+  return digits || null;
+}
+
+function normalizeDate(value) {
+  return formatDate(value) || value || null;
+}
+
+function normalizeDateTime(value) {
+  const dt = toPacific(value);
+  return dt ? dt.toISO({ suppressMilliseconds: true }) : value || null;
+}
+
+function seedMaster(db) {
+  const masterPath = path.resolve(__dirname, '../fixtures/master.sample.csv');
+  const content = fs.readFileSync(masterPath, 'utf8');
+  const records = parse(content, { columns: true, skip_empty_lines: true });
+  db.prepare('DELETE FROM master').run();
+  const insert = db.prepare(`INSERT INTO master (
+    RootApptID, VisitDate, Customer, Phone, PhoneNorm, Email, EmailLower,
+    VisitType, VisitNumber, SO, Brand, SalesStage, ConversionStatus,
+    CustomOrderStatus, CenterStoneOrderStatus, AssignedRep, AssistedRep
+  ) VALUES (
+    @RootApptID, @VisitDate, @Customer, @Phone, @PhoneNorm, @Email, @EmailLower,
+    @VisitType, @VisitNumber, @SO, @Brand, @SalesStage, @ConversionStatus,
+    @CustomOrderStatus, @CenterStoneOrderStatus, @AssignedRep, @AssistedRep
+  )`);
+
+  const transaction = db.transaction((rows) => {
+    for (const record of rows) {
+      const map = createNormalizedMap(record);
+      const phone = resolveField(map, 'Phone', MASTER_HEADER_ALIASES);
+      const email = resolveField(map, 'Email', MASTER_HEADER_ALIASES);
+      insert.run({
+        RootApptID: resolveField(map, 'RootApptID', MASTER_HEADER_ALIASES),
+        VisitDate: normalizeDate(resolveField(map, 'VisitDate', MASTER_HEADER_ALIASES)),
+        Customer: resolveField(map, 'Customer', MASTER_HEADER_ALIASES),
+        Phone: phone,
+        PhoneNorm: normalizePhone(resolveField(map, 'PhoneNorm', MASTER_HEADER_ALIASES) || phone),
+        Email: email,
+        EmailLower: (resolveField(map, 'EmailLower', MASTER_HEADER_ALIASES) || email || '').toLowerCase(),
+        VisitType: resolveField(map, 'VisitType', MASTER_HEADER_ALIASES),
+        VisitNumber: resolveField(map, 'VisitNumber', MASTER_HEADER_ALIASES),
+        SO: resolveField(map, 'SO', MASTER_HEADER_ALIASES),
+        Brand: resolveField(map, 'Brand', MASTER_HEADER_ALIASES),
+        SalesStage: resolveField(map, 'SalesStage', MASTER_HEADER_ALIASES),
+        ConversionStatus: resolveField(map, 'ConversionStatus', MASTER_HEADER_ALIASES),
+        CustomOrderStatus: resolveField(map, 'CustomOrderStatus', MASTER_HEADER_ALIASES),
+        CenterStoneOrderStatus: resolveField(map, 'CenterStoneOrderStatus', MASTER_HEADER_ALIASES),
+        AssignedRep: resolveField(map, 'AssignedRep', MASTER_HEADER_ALIASES),
+        AssistedRep: resolveField(map, 'AssistedRep', MASTER_HEADER_ALIASES),
+      });
+    }
+  });
+  transaction(records);
+  logger.info('Seeded master table with %d rows', records.length);
+}
+
+function seedLedger(db) {
+  const ledgerPath = path.resolve(__dirname, '../fixtures/ledger.sample.csv');
+  const content = fs.readFileSync(ledgerPath, 'utf8');
+  const records = parse(content, { columns: true, skip_empty_lines: true });
+  db.prepare('DELETE FROM payments').run();
+  const insert = db.prepare(`INSERT INTO payments (
+    RootApptID, PaymentDateTime, DocType, AmountNet, DocStatus, Raw
+  ) VALUES (
+    @RootApptID, @PaymentDateTime, @DocType, @AmountNet, @DocStatus, @Raw
+  )`);
+  const transaction = db.transaction((rows) => {
+    for (const record of rows) {
+      const map = createNormalizedMap(record);
+      insert.run({
+        RootApptID: resolveField(map, 'RootApptID', LEDGER_HEADER_ALIASES),
+        PaymentDateTime: normalizeDateTime(resolveField(map, 'PaymentDateTime', LEDGER_HEADER_ALIASES)),
+        DocType: resolveField(map, 'DocType', LEDGER_HEADER_ALIASES),
+        AmountNet: Number(resolveField(map, 'AmountNet', LEDGER_HEADER_ALIASES) || 0),
+        DocStatus: resolveField(map, 'DocStatus', LEDGER_HEADER_ALIASES),
+        Raw: JSON.stringify(record),
+      });
+    }
+  });
+  transaction(records);
+  logger.info('Seeded payments table with %d rows', records.length);
+}
+
+export function seedDatabase() {
+  const db = getDatabase();
+  seedMaster(db);
+  seedLedger(db);
+}
+
+if (process.argv[1] === __filename) {
+  seedDatabase();
+}

--- a/src/adapters/DriveService.js
+++ b/src/adapters/DriveService.js
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import config from '../main/config.js';
+
+const REQUIRED_SUBDIRS = ['03_Transcripts', '04_Summaries', '05_ChatLogs'];
+
+function newestFile(files = []) {
+  return files.sort((a, b) => b.mtimeMs - a.mtimeMs)[0] || null;
+}
+
+class DriveService {
+  constructor(rootPath) {
+    this.rootPath = rootPath || path.resolve('./drive');
+  }
+
+  clientFolder(rootApptId) {
+    const folder = path.join(this.rootPath, rootApptId);
+    fs.mkdirSync(folder, { recursive: true });
+    for (const sub of REQUIRED_SUBDIRS) {
+      fs.mkdirSync(path.join(folder, sub), { recursive: true });
+    }
+    return folder;
+  }
+
+  listFolder(folderPath) {
+    if (!fs.existsSync(folderPath)) {
+      return [];
+    }
+    return fs
+      .readdirSync(folderPath)
+      .map((name) => {
+        const full = path.join(folderPath, name);
+        const stats = fs.statSync(full);
+        return { name, path: full, mtimeMs: stats.mtimeMs, stats };
+      })
+      .filter((entry) => entry.stats.isFile());
+  }
+
+  getNewestTranscript(rootApptId) {
+    const folder = this.clientFolder(rootApptId);
+    const transcripts = this.listFolder(path.join(folder, '03_Transcripts'));
+    return newestFile(transcripts);
+  }
+
+  getNewestSummaryArtifact(rootApptId) {
+    const folder = this.clientFolder(rootApptId);
+    const summaries = this.listFolder(path.join(folder, '04_Summaries'));
+    const candidates = summaries.filter((file) =>
+      /__(summary|summary_corrected|analysis)__/.test(file.name.toLowerCase()) && file.name.endsWith('.json'),
+    );
+    return newestFile(candidates);
+  }
+}
+
+let driveInstance;
+
+export function getDriveService() {
+  if (!driveInstance) {
+    const root = config.get('LOCAL_DRIVE_ROOT', path.resolve('./drive'));
+    driveInstance = new DriveService(root);
+  }
+  return driveInstance;
+}
+
+export default DriveService;

--- a/src/adapters/LedgerService.js
+++ b/src/adapters/LedgerService.js
@@ -1,0 +1,70 @@
+import { getDatabase } from '../main/db.js';
+import config from '../main/config.js';
+import { formatDateTime } from '../main/utils/time.js';
+
+class LedgerService {
+  constructor(db) {
+    this.db = db;
+    this.enabled = Boolean(config.get('PAYMENTS_400_FILE_ID'));
+  }
+
+  receiptFilterWhereClauses() {
+    return `LOWER(DocType) LIKE '%receipt%' AND AmountNet > 0
+      AND COALESCE(LOWER(DocStatus), '') NOT IN ('void', 'reversed', 'cancelled')`;
+  }
+
+  getReceiptDeposits(filters = {}) {
+    if (!this.enabled) {
+      return [];
+    }
+    const clauses = [this.receiptFilterWhereClauses()];
+    const params = {};
+    if (filters.rootApptId) {
+      clauses.push('RootApptID = @rootApptId');
+      params.rootApptId = filters.rootApptId;
+    }
+    if (filters.startDate) {
+      clauses.push('PaymentDateTime >= @startDate');
+      params.startDate = formatDateTime(filters.startDate);
+    }
+    if (filters.endDate) {
+      clauses.push('PaymentDateTime <= @endDate');
+      params.endDate = formatDateTime(filters.endDate);
+    }
+    let sql = `SELECT RootApptID, PaymentDateTime, DocType, AmountNet, DocStatus
+      FROM payments`;
+    if (clauses.length) {
+      sql += ` WHERE ${clauses.join(' AND ')}`;
+    }
+    sql += ' ORDER BY PaymentDateTime ASC';
+    return this.db.prepare(sql).all(params);
+  }
+
+  firstRealDeposit(rootApptId) {
+    const deposits = this.getReceiptDeposits({ rootApptId });
+    return deposits.length ? deposits[0] : null;
+  }
+
+  depositsInWindow(startDate, endDate) {
+    return this.getReceiptDeposits({ startDate, endDate });
+  }
+
+  depositTotalInWindow(startDate, endDate) {
+    const deposits = this.depositsInWindow(startDate, endDate);
+    if (!deposits.length) {
+      return 0;
+    }
+    return deposits.reduce((acc, row) => acc + Number(row.AmountNet || 0), 0);
+  }
+}
+
+let ledgerInstance;
+
+export function getLedgerService() {
+  if (!ledgerInstance) {
+    ledgerInstance = new LedgerService(getDatabase());
+  }
+  return ledgerInstance;
+}
+
+export default LedgerService;

--- a/src/adapters/PerClientReportService.js
+++ b/src/adapters/PerClientReportService.js
@@ -1,0 +1,86 @@
+import { getDatabase } from '../main/db.js';
+import { logger } from '../main/logger.js';
+import { PER_CLIENT_LOG_HEADERS } from '../main/alias-registry.js';
+
+const META_KEY_SCHEMA = 'perClientReport.headers';
+
+class PerClientReportService {
+  constructor(db) {
+    this.db = db;
+  }
+
+  ensureSchema(headers) {
+    const existing = this.getStoredSchema();
+    if (!existing) {
+      this.storeSchema(headers);
+      return headers;
+    }
+    const normalizedExisting = JSON.stringify(existing);
+    const normalizedIncoming = JSON.stringify(headers);
+    if (normalizedExisting !== normalizedIncoming) {
+      logger.warn('Per-client report headers mismatch. Keeping stored schema.');
+    }
+    return existing;
+  }
+
+  storeSchema(headers) {
+    const payload = JSON.stringify(headers);
+    this.db
+      .prepare(`INSERT INTO meta (key, value) VALUES (@key, @value)
+        ON CONFLICT(key) DO UPDATE SET value=excluded.value`)
+      .run({ key: META_KEY_SCHEMA, value: payload });
+  }
+
+  getStoredSchema() {
+    const row = this.db.prepare('SELECT value FROM meta WHERE key = @key').get({ key: META_KEY_SCHEMA });
+    if (!row) {
+      return null;
+    }
+    try {
+      return JSON.parse(row.value);
+    } catch (error) {
+      logger.error('Failed to parse stored per-client schema: %o', error);
+      return null;
+    }
+  }
+
+  appendEntries(rootApptId, entries = []) {
+    if (!entries.length) {
+      return 0;
+    }
+    const headers = Object.keys(PER_CLIENT_LOG_HEADERS);
+    this.ensureSchema(headers);
+    const insert = this.db.prepare(`INSERT INTO client_status_entries (
+      RootApptID, LogDate, SalesStage, ConversionStatus, CustomOrderStatus,
+      CenterStoneOrderStatus, NextSteps, DeadlineType, DeadlineDate,
+      MoveCount, AssistedRep, UpdatedBy, UpdatedAt
+    ) VALUES (
+      @RootApptID, @LogDate, @SalesStage, @ConversionStatus, @CustomOrderStatus,
+      @CenterStoneOrderStatus, @NextSteps, @DeadlineType, @DeadlineDate,
+      @MoveCount, @AssistedRep, @UpdatedBy, @UpdatedAt
+    )`);
+    const transaction = this.db.transaction((payload) => {
+      for (const row of payload) {
+        insert.run({ ...row, RootApptID: rootApptId });
+      }
+    });
+    transaction(entries);
+    return entries.length;
+  }
+
+  listEntries(rootApptId) {
+    const stmt = this.db.prepare(`SELECT * FROM client_status_entries WHERE RootApptID = @rootApptId ORDER BY LogDate ASC, rowid ASC`);
+    return stmt.all({ rootApptId });
+  }
+}
+
+let serviceInstance;
+
+export function getPerClientReportService() {
+  if (!serviceInstance) {
+    serviceInstance = new PerClientReportService(getDatabase());
+  }
+  return serviceInstance;
+}
+
+export default PerClientReportService;

--- a/src/adapters/SchedulerService.js
+++ b/src/adapters/SchedulerService.js
@@ -1,0 +1,100 @@
+import { getDatabase } from '../main/db.js';
+import { logger } from '../main/logger.js';
+import { now, toPacific } from '../main/utils/time.js';
+
+const META_PREFIX = 'scheduler.lastRun.';
+
+class SchedulerService {
+  constructor(db) {
+    this.db = db;
+    this.jobs = new Map();
+  }
+
+  getLastRun(name) {
+    const row = this.db.prepare('SELECT value FROM meta WHERE key = @key').get({ key: META_PREFIX + name });
+    if (!row) {
+      return null;
+    }
+    return toPacific(row.value);
+  }
+
+  recordRun(name, timestamp) {
+    const value = timestamp.toISO();
+    this.db
+      .prepare(`INSERT INTO meta (key, value) VALUES (@key, @value)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value`)
+      .run({ key: META_PREFIX + name, value });
+  }
+
+  shouldRun(job, referenceTime) {
+    const { spec, name } = job;
+    const lastRun = this.getLastRun(name);
+    if (spec.oncePerDay !== false && lastRun && lastRun.hasSame(referenceTime, 'day')) {
+      return false;
+    }
+    if (spec.daysOfWeek && spec.daysOfWeek.length) {
+      if (!spec.daysOfWeek.includes(referenceTime.weekday)) {
+        return false;
+      }
+    }
+    const scheduledTime = referenceTime.set({ hour: spec.hour, minute: spec.minute || 0, second: 0, millisecond: 0 });
+    if (referenceTime < scheduledTime) {
+      return false;
+    }
+    if (lastRun && referenceTime.diff(lastRun, 'minutes').minutes < 1) {
+      return false;
+    }
+    return true;
+  }
+
+  evaluate(job) {
+    const referenceTime = now();
+    if (!this.shouldRun(job, referenceTime)) {
+      return;
+    }
+    try {
+      Promise.resolve(job.fn()).finally(() => {
+        this.recordRun(job.name, referenceTime);
+        logger.info('Scheduler ran job %s at %s', job.name, referenceTime.toISO());
+      });
+    } catch (error) {
+      logger.error('Scheduler job %s failed: %o', job.name, error);
+    }
+  }
+
+  register(name, cronLikeSpec, fn) {
+    const job = { name, spec: cronLikeSpec, fn };
+    this.jobs.set(name, job);
+    this.evaluate(job);
+    job.timer = setInterval(() => this.evaluate(job), 60 * 1000);
+    return () => this.unregister(name);
+  }
+
+  unregister(name) {
+    const job = this.jobs.get(name);
+    if (!job) {
+      return;
+    }
+    if (job.timer) {
+      clearInterval(job.timer);
+    }
+    this.jobs.delete(name);
+  }
+
+  shutdown() {
+    for (const name of this.jobs.keys()) {
+      this.unregister(name);
+    }
+  }
+}
+
+let schedulerInstance;
+
+export function getSchedulerService() {
+  if (!schedulerInstance) {
+    schedulerInstance = new SchedulerService(getDatabase());
+  }
+  return schedulerInstance;
+}
+
+export default SchedulerService;

--- a/src/adapters/SheetsService.js
+++ b/src/adapters/SheetsService.js
@@ -1,0 +1,169 @@
+import { getDatabase } from '../main/db.js';
+import { formatDate } from '../main/utils/time.js';
+import { logger } from '../main/logger.js';
+
+const DEFAULT_STAGE_WEIGHTS = [
+  { Stage: 'LEAD', Weight: 0.1 },
+  { Stage: 'HOT LEAD', Weight: 0.2 },
+  { Stage: 'CONSULT', Weight: 0.3 },
+  { Stage: 'DIAMOND VIEWING', Weight: 0.5 },
+  { Stage: 'DEPOSIT', Weight: 0.9 },
+  { Stage: 'ORDER COMPLETED', Weight: 0.0 },
+];
+
+class SheetsService {
+  constructor(db) {
+    this.db = db;
+  }
+
+  getMasterRows(filters = {}) {
+    const clauses = [];
+    const params = {};
+
+    if (filters.brand) {
+      clauses.push('LOWER(Brand) = LOWER(@brand)');
+      params.brand = filters.brand;
+    }
+    if (filters.rep) {
+      clauses.push('LOWER(AssignedRep) = LOWER(@rep) OR LOWER(AssistedRep) = LOWER(@rep)');
+      params.rep = filters.rep;
+    }
+    if (filters.startDate) {
+      clauses.push('VisitDate >= @startDate');
+      params.startDate = formatDate(filters.startDate);
+    }
+    if (filters.endDate) {
+      clauses.push('VisitDate <= @endDate');
+      params.endDate = formatDate(filters.endDate);
+    }
+
+    let sql = `SELECT RootApptID, VisitDate, Customer, Phone, PhoneNorm, Email, EmailLower,
+      VisitType, VisitNumber, SO, Brand, SalesStage, ConversionStatus, CustomOrderStatus,
+      CenterStoneOrderStatus, AssignedRep, AssistedRep
+      FROM master`;
+    if (clauses.length) {
+      sql += ` WHERE ${clauses.join(' AND ')}`;
+    }
+    sql += ' ORDER BY VisitDate ASC, RootApptID ASC';
+
+    const stmt = this.db.prepare(sql);
+    return stmt.all(params).map((row) => ({
+      VisitDate: row.VisitDate,
+      RootApptID: row.RootApptID,
+      Customer: row.Customer,
+      Phone: row.Phone || row.PhoneNorm,
+      Email: row.Email || row.EmailLower,
+      VisitType: row.VisitType,
+      VisitNumber: row.VisitNumber,
+      SO: row.SO,
+      Brand: row.Brand,
+      SalesStage: row.SalesStage,
+      ConversionStatus: row.ConversionStatus,
+      CustomOrderStatus: row.CustomOrderStatus,
+      CenterStoneOrderStatus: row.CenterStoneOrderStatus,
+      AssignedRep: row.AssignedRep,
+      AssistedRep: row.AssistedRep,
+    }));
+  }
+
+  getClientStatusLog(limit = 100) {
+    const stmt = this.db.prepare(`SELECT * FROM client_status_log ORDER BY UpdatedAt DESC LIMIT @limit`);
+    return stmt.all({ limit });
+  }
+
+  appendClientStatusLog(entries = []) {
+    if (!entries.length) {
+      return 0;
+    }
+    const insert = this.db.prepare(`INSERT INTO client_status_log (
+      LogDate, SalesStage, ConversionStatus, CustomOrderStatus, CenterStoneOrderStatus,
+      NextSteps, DeadlineType, DeadlineDate, MoveCount, AssistedRep, UpdatedBy, UpdatedAt
+    ) VALUES (
+      @LogDate, @SalesStage, @ConversionStatus, @CustomOrderStatus, @CenterStoneOrderStatus,
+      @NextSteps, @DeadlineType, @DeadlineDate, @MoveCount, @AssistedRep, @UpdatedBy, @UpdatedAt
+    )`);
+    const transaction = this.db.transaction((rows) => {
+      for (const row of rows) {
+        insert.run(row);
+      }
+    });
+    transaction(entries);
+    return entries.length;
+  }
+
+  upsertAckSnapshot(rows = []) {
+    const insert = this.db.prepare(`INSERT INTO ack_snapshot (
+      SnapshotDate, CapturedAt, RootApptID, Rep, Role, ScopeGroup, CustomerName,
+      SalesStage, ConversionStatus, CustomOrderStatus, UpdatedBy, UpdatedAt,
+      DaysSinceLastUpdate, ClientStatusReportURL
+    ) VALUES (
+      @SnapshotDate, @CapturedAt, @RootApptID, @Rep, @Role, @ScopeGroup, @CustomerName,
+      @SalesStage, @ConversionStatus, @CustomOrderStatus, @UpdatedBy, @UpdatedAt,
+      @DaysSinceLastUpdate, @ClientStatusReportURL
+    )`);
+    const clear = this.db.prepare('DELETE FROM ack_snapshot');
+    const transaction = this.db.transaction((data) => {
+      clear.run();
+      for (const row of data) {
+        insert.run(row);
+      }
+    });
+    transaction(rows);
+  }
+
+  appendAckSnapshotLog(rows = []) {
+    if (!rows.length) {
+      return;
+    }
+    const insert = this.db.prepare(`INSERT INTO ack_snapshot_log (
+      SnapshotDate, CapturedAt, RootApptID, Rep, Role, ScopeGroup, CustomerName,
+      SalesStage, ConversionStatus, CustomOrderStatus, UpdatedBy, UpdatedAt,
+      DaysSinceLastUpdate, ClientStatusReportURL
+    ) VALUES (
+      @SnapshotDate, @CapturedAt, @RootApptID, @Rep, @Role, @ScopeGroup, @CustomerName,
+      @SalesStage, @ConversionStatus, @CustomOrderStatus, @UpdatedBy, @UpdatedAt,
+      @DaysSinceLastUpdate, @ClientStatusReportURL
+    )`);
+    const transaction = this.db.transaction((data) => {
+      for (const row of data) {
+        insert.run(row);
+      }
+    });
+    transaction(rows);
+  }
+
+  getDashboardStageWeights() {
+    const stmt = this.db.prepare('SELECT Stage, Weight FROM dashboard_weights ORDER BY Stage ASC');
+    const rows = stmt.all();
+    if (!rows.length) {
+      return DEFAULT_STAGE_WEIGHTS;
+    }
+    return rows;
+  }
+
+  setDashboardStageWeights(weights = []) {
+    const cleared = this.db.prepare('DELETE FROM dashboard_weights');
+    const insert = this.db.prepare('INSERT INTO dashboard_weights (Stage, Weight) VALUES (@Stage, @Weight)');
+    const transaction = this.db.transaction((data) => {
+      cleared.run();
+      for (const row of data) {
+        insert.run(row);
+      }
+    });
+    const payload = weights.length ? weights : DEFAULT_STAGE_WEIGHTS;
+    transaction(payload);
+    logger.info('Dashboard weights updated (%d rows)', payload.length);
+  }
+}
+
+let sheetsServiceInstance;
+
+export function getSheetsService() {
+  if (!sheetsServiceInstance) {
+    sheetsServiceInstance = new SheetsService(getDatabase());
+  }
+  return sheetsServiceInstance;
+}
+
+export default SheetsService;
+

--- a/src/domain/AppointmentSummary.js
+++ b/src/domain/AppointmentSummary.js
@@ -1,0 +1,41 @@
+import { getSheetsService } from '../adapters/SheetsService.js';
+import { APPOINTMENT_SUMMARY_HEADERS } from '../main/alias-registry.js';
+import { formatDate } from '../main/utils/time.js';
+
+export class AppointmentSummary {
+  constructor() {
+    this.sheetsService = getSheetsService();
+  }
+
+  run(filters = {}) {
+    const rows = this.sheetsService.getMasterRows({
+      brand: filters.brand,
+      rep: filters.rep,
+      startDate: filters.startDate,
+      endDate: filters.endDate,
+    });
+    const data = rows.map((row) => [
+      formatDate(row.VisitDate) || row.VisitDate,
+      row.RootApptID,
+      row.Customer,
+      row.Phone,
+      row.Email,
+      row.VisitType,
+      row.VisitNumber,
+      row.SO,
+      row.Brand,
+      row.SalesStage,
+      row.ConversionStatus,
+      row.CustomOrderStatus,
+      row.CenterStoneOrderStatus,
+      row.AssignedRep,
+      row.AssistedRep,
+    ]);
+    return {
+      headers: APPOINTMENT_SUMMARY_HEADERS,
+      rows: data,
+    };
+  }
+}
+
+export default AppointmentSummary;

--- a/src/main/alias-registry.js
+++ b/src/main/alias-registry.js
@@ -1,0 +1,118 @@
+import { normalizeHeaderName } from './utils/headerMap.js';
+
+const MASTER_HEADER_ALIASES = {
+  VisitDate: ['Visit Date', 'VisitDate', 'Appt Date', 'Appointment Date'],
+  RootApptID: ['RootApptID', 'Root Appt ID', 'ROOT', 'Root_ID'],
+  Customer: ['Customer', 'Customer Name', 'Client Name'],
+  Phone: ['Phone', 'Phone Number', 'Primary Phone'],
+  PhoneNorm: ['PhoneNorm', 'Phone Normalized', 'Phone (Normalized)'],
+  Email: ['Email', 'Customer Email'],
+  EmailLower: ['EmailLower', 'Email (Lower)', 'Email Lower'],
+  VisitType: ['Visit Type', 'Appt Type', 'Type'],
+  VisitNumber: ['Visit #', 'Visit Number', 'Appt #'],
+  SO: ['SO#', 'SO Number', 'Sales Order'],
+  Brand: ['Brand'],
+  SalesStage: ['Sales Stage', 'Stage'],
+  ConversionStatus: ['Conversion Status', 'Conversion'],
+  CustomOrderStatus: ['Custom Order Status', 'Custom Status'],
+  CenterStoneOrderStatus: ['Center Stone Order Status', 'Center Stone Status'],
+  AssignedRep: ['Assigned Rep', 'Primary Rep'],
+  AssistedRep: ['Assisted Rep', 'Secondary Rep'],
+};
+
+const LEDGER_HEADER_ALIASES = {
+  RootApptID: ['RootApptID', 'Root Appt ID', 'ROOT', 'Root_ID'],
+  PaymentDateTime: ['PaymentDateTime', 'Payment DateTime', 'Payment Date', 'Paid At'],
+  DocType: ['DocType', 'Document Type', 'Type'],
+  AmountNet: ['AmountNet', 'Net', 'Net Amount'],
+  DocStatus: ['DocStatus', 'Status'],
+};
+
+const SNAPSHOT_ALIASES = {
+  SnapshotDate: ['Snapshot Date'],
+  CapturedAt: ['Captured At'],
+  RootApptID: ['RootApptID', 'Root Appt ID'],
+  Rep: ['Rep', 'Assigned Rep'],
+  Role: ['Role'],
+  ScopeGroup: ['Scope Group'],
+  CustomerName: ['Customer Name', 'Customer'],
+  SalesStage: ['Sales Stage', 'Stage'],
+  ConversionStatus: ['Conversion Status'],
+  CustomOrderStatus: ['Custom Order Status'],
+  UpdatedBy: ['Updated By'],
+  UpdatedAt: ['Updated At'],
+  DaysSinceLastUpdate: ['Days Since Last Update'],
+  ClientStatusReportURL: ['Client Status Report URL'],
+};
+
+const PER_CLIENT_LOG_HEADERS = {
+  LogDate: ['Log Date'],
+  SalesStage: ['Sales Stage'],
+  ConversionStatus: ['Conversion Status'],
+  CustomOrderStatus: ['Custom Order Status'],
+  CenterStoneOrderStatus: ['Center Stone Order Status'],
+  NextSteps: ['Next Steps'],
+  DeadlineType: ['Deadline Type'],
+  DeadlineDate: ['Deadline Date'],
+  MoveCount: ['Move Count'],
+  AssistedRep: ['Assisted Rep'],
+  UpdatedBy: ['Updated By'],
+  UpdatedAt: ['Updated At'],
+};
+
+export const APPOINTMENT_SUMMARY_HEADERS = [
+  'Visit Date',
+  'RootApptID',
+  'Customer',
+  'Phone',
+  'Email',
+  'Visit Type',
+  'Visit #',
+  'SO#',
+  'Brand',
+  'Sales Stage',
+  'Conversion Status',
+  'Custom Order Status',
+  'Center Stone Order Status',
+  'Assigned Rep',
+  'Assisted Rep',
+];
+
+function resolveHeader(headers, aliases, canonical) {
+  const candidates = aliases[canonical] || [canonical];
+  const normalizedHeaders = headers.map((header) => normalizeHeaderName(header));
+  for (const candidate of candidates) {
+    const normalized = normalizeHeaderName(candidate);
+    const index = normalizedHeaders.indexOf(normalized);
+    if (index !== -1) {
+      return headers[index];
+    }
+  }
+  return null;
+}
+
+export function selectFirstMatchingHeader(headers, canonical, collection = MASTER_HEADER_ALIASES) {
+  return resolveHeader(headers, collection, canonical);
+}
+
+export function getAliasSet(collectionName) {
+  switch (collectionName) {
+    case 'master':
+      return MASTER_HEADER_ALIASES;
+    case 'ledger':
+      return LEDGER_HEADER_ALIASES;
+    case 'snapshot':
+      return SNAPSHOT_ALIASES;
+    case 'perClient':
+      return PER_CLIENT_LOG_HEADERS;
+    default:
+      return {};
+  }
+}
+
+export {
+  MASTER_HEADER_ALIASES,
+  LEDGER_HEADER_ALIASES,
+  SNAPSHOT_ALIASES,
+  PER_CLIENT_LOG_HEADERS,
+};

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import dotenv from 'dotenv';
+
+const CONFIG_KEY_ALIASES = {
+  REPORT_REANLYZE_TOKEN: 'REPORT_REANALYZE_TOKEN',
+};
+
+function loadEnvFile() {
+  const explicitPath = process.env.ENV_PATH || process.env.CONFIG_PATH;
+  const defaultPath = path.resolve('.env');
+  const targetPath = explicitPath ? path.resolve(explicitPath) : defaultPath;
+  if (fs.existsSync(targetPath)) {
+    dotenv.config({ path: targetPath });
+  }
+}
+
+loadEnvFile();
+
+function normalizeKey(key) {
+  return key ? key.toString().trim().toUpperCase() : '';
+}
+
+function resolveKey(key) {
+  const normalized = normalizeKey(key);
+  const alias = CONFIG_KEY_ALIASES[normalized];
+  if (alias) {
+    const aliasValue = process.env[alias];
+    if (aliasValue !== undefined) {
+      return aliasValue;
+    }
+  }
+  return process.env[normalized] ?? process.env[key] ?? null;
+}
+
+export function get(key, fallback = null) {
+  const value = resolveKey(key);
+  if (value === null || value === undefined || value === '') {
+    if (fallback !== null) {
+      return fallback;
+    }
+    return null;
+  }
+  return value;
+}
+
+export function getBoolean(key, fallback = false) {
+  const value = resolveKey(key);
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.toString().toLowerCase());
+}
+
+export function getNumber(key, fallback = null) {
+  const value = resolveKey(key);
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+  const num = Number(value);
+  return Number.isNaN(num) ? fallback : num;
+}
+
+export function asObject() {
+  return new Proxy(
+    {},
+    {
+      get: (_, prop) => get(prop),
+      has: (_, prop) => resolveKey(prop) !== null,
+    },
+  );
+}
+
+const config = {
+  get,
+  getBoolean,
+  getNumber,
+  asObject,
+};
+
+export default config;

--- a/src/main/db.js
+++ b/src/main/db.js
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import config from './config.js';
+import { logger } from './logger.js';
+
+let dbInstance = null;
+
+export function getDatabase() {
+  if (dbInstance) {
+    return dbInstance;
+  }
+  const configuredPath = config.get('DATABASE_PATH', './data/app.db');
+  const resolvedPath = path.resolve(configuredPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  logger.debug('Opening SQLite database at %s', resolvedPath);
+  dbInstance = new Database(resolvedPath);
+  dbInstance.pragma('journal_mode = WAL');
+  return dbInstance;
+}
+
+export default getDatabase;

--- a/src/main/electron.js
+++ b/src/main/electron.js
@@ -1,0 +1,57 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AppointmentSummary } from '../domain/AppointmentSummary.js';
+import { getSchedulerService } from '../adapters/SchedulerService.js';
+import { logger } from './logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      preload: path.join(__dirname, '../ui/preload.js'),
+    },
+  });
+
+  win.loadFile(path.join(__dirname, '../ui/index.html'));
+}
+
+function setupSchedulers() {
+  const scheduler = getSchedulerService();
+  scheduler.register('morningSnapshot', { hour: 8, minute: 30 }, () => {
+    logger.info('Morning snapshot job (stub) executed.');
+  });
+  scheduler.register('middayQueues', { hour: 13, minute: 0 }, () => {
+    logger.info('Midday queues job (stub) executed.');
+  });
+  scheduler.register('lateDayDashboard', { hour: 16, minute: 30 }, () => {
+    logger.info('Late-day dashboard job (stub) executed.');
+  });
+}
+
+ipcMain.handle('appointment-summary:run', async (event, filters = {}) => {
+  const summary = new AppointmentSummary();
+  return summary.run(filters);
+});
+
+app.whenReady().then(() => {
+  createWindow();
+  setupSchedulers();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    getSchedulerService().shutdown();
+    app.quit();
+  }
+});

--- a/src/main/logger.js
+++ b/src/main/logger.js
@@ -1,0 +1,24 @@
+import { format } from 'node:util';
+import { DateTime } from 'luxon';
+
+const LEVELS = ['debug', 'info', 'warn', 'error'];
+
+function log(level, message, ...args) {
+  if (!LEVELS.includes(level)) {
+    level = 'info';
+  }
+  const timestamp = DateTime.now().setZone('America/Los_Angeles').toISO();
+  const line = typeof message === 'string' ? format(message, ...args) : format('%o', message);
+  const output = `[${timestamp}] [${level.toUpperCase()}] ${line}`;
+  // eslint-disable-next-line no-console
+  console[level === 'debug' ? 'log' : level](output);
+}
+
+export const logger = {
+  debug: (msg, ...args) => log('debug', msg, ...args),
+  info: (msg, ...args) => log('info', msg, ...args),
+  warn: (msg, ...args) => log('warn', msg, ...args),
+  error: (msg, ...args) => log('error', msg, ...args),
+};
+
+export default logger;

--- a/src/main/utils/headerMap.js
+++ b/src/main/utils/headerMap.js
@@ -1,0 +1,88 @@
+export function normalizeHeaderName(name) {
+  return name ? name.toString().trim().replace(/[_\s]+/g, ' ').toLowerCase() : '';
+}
+
+export function createHeaderMap(headers = []) {
+  const headerRow = headers.slice();
+  const normalizedToIndex = new Map();
+  headerRow.forEach((header, index) => {
+    normalizedToIndex.set(normalizeHeaderName(header), index);
+  });
+
+  function ensureHeader(name) {
+    const normalized = normalizeHeaderName(name);
+    if (!normalizedToIndex.has(normalized)) {
+      headerRow.push(name);
+      normalizedToIndex.set(normalized, headerRow.length - 1);
+    }
+  }
+
+  function getIndex(name) {
+    const normalized = normalizeHeaderName(name);
+    if (normalizedToIndex.has(normalized)) {
+      return normalizedToIndex.get(normalized);
+    }
+    return null;
+  }
+
+  function getOrThrow(name) {
+    const index = getIndex(name);
+    if (index === null || index === undefined) {
+      throw new Error(`Header not found: ${name}`);
+    }
+    return index;
+  }
+
+  function getOrNull(name) {
+    const index = getIndex(name);
+    return index === undefined ? null : index;
+  }
+
+  function resolveAlias(names) {
+    const candidates = Array.isArray(names) ? names : [names];
+    for (const candidate of candidates) {
+      const index = getIndex(candidate);
+      if (index !== null && index !== undefined) {
+        return index;
+      }
+    }
+    return null;
+  }
+
+  function toRow(valuesByHeader = {}) {
+    const row = new Array(headerRow.length).fill('');
+    Object.entries(valuesByHeader).forEach(([header, value]) => {
+      ensureHeader(header);
+      const index = getIndex(header);
+      row[index] = value;
+    });
+    return row;
+  }
+
+  return {
+    headerRow,
+    ensureHeader,
+    getIndex,
+    getOrThrow,
+    getOrNull,
+    resolveAlias,
+    toRow,
+  };
+}
+
+export function getValue(row, headerMap, aliases) {
+  const index = headerMap.resolveAlias(aliases);
+  if (index === null || index === undefined) {
+    return null;
+  }
+  return row[index] ?? null;
+}
+
+export function setValue(row, headerMap, headerName, value) {
+  headerMap.ensureHeader(headerName);
+  const index = headerMap.getIndex(headerName);
+  row[index] = value;
+  return row;
+}
+
+export default createHeaderMap;

--- a/src/main/utils/time.js
+++ b/src/main/utils/time.js
@@ -1,0 +1,83 @@
+import { DateTime } from 'luxon';
+
+const PACIFIC = 'America/Los_Angeles';
+
+export function now() {
+  return DateTime.now().setZone(PACIFIC);
+}
+
+export function toPacific(dateLike) {
+  if (!dateLike) {
+    return null;
+  }
+  if (DateTime.isDateTime(dateLike)) {
+    return dateLike.setZone(PACIFIC, { keepLocalTime: false });
+  }
+  if (dateLike instanceof Date) {
+    return DateTime.fromJSDate(dateLike, { zone: PACIFIC });
+  }
+  if (typeof dateLike === 'number') {
+    return DateTime.fromMillis(dateLike, { zone: PACIFIC });
+  }
+  if (typeof dateLike === 'string') {
+    const parsed = DateTime.fromISO(dateLike, { zone: PACIFIC });
+    if (parsed.isValid) {
+      return parsed;
+    }
+    const fallback = DateTime.fromFormat(dateLike, 'M/d/yyyy', { zone: PACIFIC });
+    if (fallback.isValid) {
+      return fallback;
+    }
+  }
+  return null;
+}
+
+export function formatDate(dateLike) {
+  const dt = toPacific(dateLike);
+  return dt ? dt.toFormat('yyyy-LL-dd') : null;
+}
+
+export function formatDateTime(dateLike) {
+  const dt = toPacific(dateLike);
+  return dt ? dt.toFormat('yyyy-LL-dd HH:mm') : null;
+}
+
+export function parseDate(dateString) {
+  const dt = toPacific(dateString);
+  return dt ? dt.startOf('day') : null;
+}
+
+export function parseDateTime(dateString) {
+  return toPacific(dateString);
+}
+
+export function isSameDay(dateA, dateB) {
+  const a = toPacific(dateA);
+  const b = toPacific(dateB);
+  if (!a || !b) {
+    return false;
+  }
+  return a.hasSame(b, 'day');
+}
+
+export function startOfDay(dateLike) {
+  const dt = toPacific(dateLike);
+  return dt ? dt.startOf('day') : null;
+}
+
+export function endOfDay(dateLike) {
+  const dt = toPacific(dateLike);
+  return dt ? dt.endOf('day') : null;
+}
+
+export default {
+  now,
+  toPacific,
+  formatDate,
+  formatDateTime,
+  parseDate,
+  parseDateTime,
+  isSameDay,
+  startOfDay,
+  endOfDay,
+};

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>HP / VVS Sales Automation</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        padding: 16px;
+      }
+      button {
+        padding: 8px 16px;
+        margin-bottom: 16px;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      th,
+      td {
+        border: 1px solid #ccc;
+        padding: 8px;
+        text-align: left;
+      }
+      th {
+        background-color: #f4f4f4;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>HP / VVS Sales Automation</h1>
+    <button id="runSummary">Run Appointment Summary</button>
+    <div id="results"></div>
+    <script type="module" src="./renderer.js"></script>
+  </body>
+</html>

--- a/src/ui/preload.js
+++ b/src/ui/preload.js
@@ -1,0 +1,5 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('appAPI', {
+  runAppointmentSummary: (filters) => ipcRenderer.invoke('appointment-summary:run', filters),
+});

--- a/src/ui/renderer.js
+++ b/src/ui/renderer.js
@@ -1,0 +1,43 @@
+const button = document.getElementById('runSummary');
+const results = document.getElementById('results');
+
+function renderTable(summary) {
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  summary.headers.forEach((header) => {
+    const th = document.createElement('th');
+    th.textContent = header;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  summary.rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    row.forEach((cell) => {
+      const td = document.createElement('td');
+      td.textContent = cell ?? '';
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  results.innerHTML = '';
+  results.appendChild(table);
+}
+
+button.addEventListener('click', async () => {
+  button.disabled = true;
+  button.textContent = 'Running...';
+  try {
+    const summary = await window.appAPI.runAppointmentSummary();
+    renderTable(summary);
+  } catch (error) {
+    results.textContent = `Failed to run summary: ${error.message}`;
+  } finally {
+    button.disabled = false;
+    button.textContent = 'Run Appointment Summary';
+  }
+});

--- a/tests/appointmentSummary.smoke.test.js
+++ b/tests/appointmentSummary.smoke.test.js
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { before, after, test } from 'node:test';
+
+const dataDir = path.resolve('./data');
+const testDbPath = path.join(dataDir, 'test.db');
+process.env.DATABASE_PATH = testDbPath;
+process.env.PAYMENTS_400_FILE_ID = 'local-ledger';
+
+let runMigrations;
+let seedDatabase;
+let AppointmentSummary;
+
+before(async () => {
+  if (fs.existsSync(testDbPath)) {
+    fs.rmSync(testDbPath);
+  }
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+  ({ runMigrations } = await import('../scripts/migrate.js'));
+  ({ seedDatabase } = await import('../scripts/seed.js'));
+  ({ AppointmentSummary } = await import('../src/domain/AppointmentSummary.js'));
+  runMigrations();
+  seedDatabase();
+});
+
+after(() => {
+  const artifacts = [testDbPath, `${testDbPath}-shm`, `${testDbPath}-wal`];
+  artifacts.forEach((file) => {
+    if (fs.existsSync(file)) {
+      fs.rmSync(file);
+    }
+  });
+});
+
+test('appointment summary returns expected headers and rows', () => {
+  const summary = new AppointmentSummary();
+  const result = summary.run();
+  assert.deepStrictEqual(result.headers, [
+    'Visit Date',
+    'RootApptID',
+    'Customer',
+    'Phone',
+    'Email',
+    'Visit Type',
+    'Visit #',
+    'SO#',
+    'Brand',
+    'Sales Stage',
+    'Conversion Status',
+    'Custom Order Status',
+    'Center Stone Order Status',
+    'Assigned Rep',
+    'Assisted Rep',
+  ]);
+  assert.ok(result.rows.length >= 3);
+  const firstRow = result.rows[0];
+  assert.equal(firstRow[0], '2024-04-01');
+  assert.equal(firstRow[1], 'HP-1001');
+  assert.equal(firstRow[7], 'SO-9001');
+  const vvsRow = result.rows.find((row) => row[1] === 'HP-1002');
+  assert.ok(vvsRow);
+  assert.equal(vvsRow[8], 'VVS');
+  assert.equal(vvsRow[10], 'Won');
+});


### PR DESCRIPTION
## Summary
- bootstrap Electron-based desktop shell with configuration, logging, and scheduler services
- implement SQLite-backed adapters for master appointments, ledger, per-client reports, and drive emulation
- add appointment summary domain flow, UI trigger, migrations, fixtures, and smoke test

## Testing
- npm run migrate
- npm run seed
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d431fa43b48329914ff4640fba366d